### PR TITLE
Rename Nib Engine to Nib, add XSD -> TS placeholder, remove Goblin Mode from artefacts

### DIFF
--- a/src/lib/data/artefacts.ts
+++ b/src/lib/data/artefacts.ts
@@ -21,9 +21,4 @@ export const artefacts: Artefact[] = [
 		repo: 'the-forgotten-one',
 		description: 'IT LIVES'
 	},
-	{
-		name: 'goblin-mode',
-		repo: 'goblin-mode',
-		description: 'Three goblins in a trenchcoat pretending to be a senior developer'
-	}
 ];

--- a/src/lib/data/projects.ts
+++ b/src/lib/data/projects.ts
@@ -87,10 +87,16 @@ export const metaProjects: Omit<Project, 'github'>[] = [
 		techLine: 'Shell / Claude Code / CLAUDE.md'
 	},
 	{
-		title: 'Nib Engine',
+		title: 'Nib',
 		repo: 'the-work',
 		description:
 			'A generic Ink + Svelte 5 runtime engine extracted from The Work. Handles story loading, reactive state via Svelte 5 runes, tag processing, and save/load — with zero knowledge of any particular game\'s mechanics. Game-specific logic is injected through a single onInit callback. Copy src/lib/engine/ to any SvelteKit project and it works. The ability to identify a reusable abstraction inside a bespoke project and extract it cleanly.',
 		techLine: 'SvelteKit / TypeScript / Ink (via inkjs) / Svelte 5 runes'
+	},
+	{
+		title: 'XSD -> TS',
+		repo: '',
+		description: '',
+		techLine: ''
 	}
 ];


### PR DESCRIPTION
- Rename "Nib Engine" to "Nib" in metaProjects
- Add placeholder "XSD -> TS" card to metaProjects
- Remove "Goblin Mode" from artefacts (already exists in metaProjects)

https://claude.ai/code/session_01623bqTtPCZnZqm5AidZZWM