### PR TITLE
Support full GitHub repo paths and improve project card UX

### DIFF
--- a/src/lib/components/ProjectCard.svelte
+++ b/src/lib/components/ProjectCard.svelte
@@ -99,7 +99,7 @@
 	{#if project.repo}
 		<div class="mt-3 flex gap-4" style="font-size: var(--text-sm);">
 			<a
-				href="https://github.com/JasonWarrenUK/{project.repo}"
+				href="https://github.com/{project.repo}"
 				target="_blank"
 				rel="noopener noreferrer"
 				class="transition-colors duration-300"

--- a/src/lib/components/ProjectCard.svelte
+++ b/src/lib/components/ProjectCard.svelte
@@ -35,9 +35,11 @@
 	}
 
 	function splitOverview(desc: string): { overview: string; detail: string } {
-		const idx = desc.indexOf('. ');
-		if (idx === -1) return { overview: desc, detail: '' };
-		return { overview: desc.slice(0, idx + 1), detail: desc.slice(idx + 2) };
+		// Match '. ' or '." ' as sentence boundaries
+		const match = desc.match(/\.\s|\."\s/);
+		if (!match || match.index === undefined) return { overview: desc, detail: '' };
+		const end = match.index + match[0].length;
+		return { overview: desc.slice(0, end).trimEnd(), detail: desc.slice(end) };
 	}
 
 	const { overview, detail } = $derived(splitOverview(project.description));
@@ -59,7 +61,7 @@
 		{overview}
 	</p>
 
-	{#if detail}
+	{#if detail || children}
 		<button
 			type="button"
 			onclick={() => expanded = !expanded}
@@ -69,9 +71,16 @@
 		</button>
 
 		{#if expanded}
-			<p class="card-detail" style="color: var(--text-secondary); line-height: 1.8; margin-bottom: 1rem;">
-				{detail}
-			</p>
+			{#if detail}
+				<p class="card-detail" style="color: var(--text-secondary); line-height: 1.8; margin-bottom: 1rem;">
+					{detail}
+				</p>
+			{/if}
+			{#if children}
+				<div class="mt-6">
+					{@render children()}
+				</div>
+			{/if}
 		{/if}
 	{/if}
 
@@ -87,24 +96,32 @@
 		{/if}
 	{/if}
 
-	<div class="mt-3 flex gap-4" style="font-size: var(--text-sm);">
-		<a
-			href="https://github.com/JasonWarrenUK/{project.repo}"
-			target="_blank"
-			rel="noopener noreferrer"
-		>
-			Repository
-		</a>
-		{#if project.liveUrl}
-			<a href={project.liveUrl} target="_blank" rel="noopener noreferrer">
-				Live
+	{#if project.repo}
+		<div class="mt-3 flex gap-4" style="font-size: var(--text-sm);">
+			<a
+				href="https://github.com/JasonWarrenUK/{project.repo}"
+				target="_blank"
+				rel="noopener noreferrer"
+				class="transition-colors duration-300"
+				style="color: var(--text-secondary);"
+				onmouseenter={(e) => ((e.currentTarget as HTMLElement).style.color = 'var(--text-primary)')}
+				onmouseleave={(e) => ((e.currentTarget as HTMLElement).style.color = 'var(--text-secondary)')}
+			>
+				Repository
 			</a>
-		{/if}
-	</div>
-
-	{#if children}
-		<div class="mt-6">
-			{@render children()}
+			{#if project.liveUrl}
+				<a
+					href={project.liveUrl}
+					target="_blank"
+					rel="noopener noreferrer"
+					class="transition-colors duration-300"
+					style="color: var(--text-secondary);"
+					onmouseenter={(e) => ((e.currentTarget as HTMLElement).style.color = 'var(--text-primary)')}
+					onmouseleave={(e) => ((e.currentTarget as HTMLElement).style.color = 'var(--text-secondary)')}
+				>
+					Live
+				</a>
+			{/if}
 		</div>
 	{/if}
 </article>

--- a/src/lib/data/projects.ts
+++ b/src/lib/data/projects.ts
@@ -3,42 +3,42 @@ import type { Project } from '$lib/types';
 export const impactProjects: Omit<Project, 'github'>[] = [
 	{
 		title: 'Rhea',
-		repo: 'rhea',
+		repo: 'foundersandcoders/rhea',
 		description:
 			'AI-powered curriculum generation for peer-led learning cohorts. Uses Claude with optional web research to generate module specifications, complete multi-week course structures, and maintain them over time. Built for democratic education: the cascade pattern means AI-generated content comes with change tracking, confidence scoring, and provenance so human curriculum councils can triage what needs review. Hierarchical domain configuration with inheritance and override.',
 		techLine: 'SvelteKit / TypeScript / LangChain / Claude API / Zod'
 	},
 	{
 		title: 'Iris',
-		repo: 'iris',
+		repo: 'foundersandcoders/iris',
 		description:
 			'ILR toolkit for apprenticeship data submission. Converts learner data from CSV exports into ILR-compliant XML for government submission, with explicit validation and cross-submission consistency checking. Ships via three interfaces: a full-screen interactive TUI, direct CLI commands, and a Tauri desktop app, all sharing a single TypeScript core. ADR-documented architectural decisions. Proper release cycle at v5.0.0.',
 		techLine: 'TypeScript / SvelteKit / Tauri / Rust / @opentui/core / Vitest'
 	},
 	{
 		title: 'Things We Do',
-		repo: 'fac-things-we-do',
+		repo: 'fac30/things-we-do',
 		description:
 			'A PWA for task management and emotional wellbeing, built for users with Tourette\'s syndrome. Mood tracking through interactive 3D visualisation. Offline-first architecture with RxDB so it works regardless of connectivity, because the people who need it most aren\'t always in places with reliable internet. Sustained over months of collaborative development.',
 		techLine: 'Next.js 15 / React 19 / TypeScript / RxDB / Tailwind / Plotly.js'
 	},
 	{
 		title: 'Commons Traybake',
-		repo: 'commons-traybake',
+		repo: 'fac-31/commons-traybake',
 		description:
 			'Civic technology for interrogating UK parliamentary data. Applies four different document chunking strategies to Hansard debates, embeds them in a Neo4j vector database, and lets users run comparative searches to see how processing decisions change which political information gets retrieved. The finding: strategies show only 8–25% overlap, proving that "neutral" data architecture encodes ideological choices.',
 		techLine: 'SvelteKit / TypeScript / Neo4j / OpenAI embeddings / UK Parliament API / Docker'
 	},
 	{
 		title: 'Sparker',
-		repo: 'sparker',
+		repo: 'JasonWarrenUK/sparker',
 		description:
 			'Observation tracking for facilitators working with students who have special educational needs. Records observations using flexible, user-defined fields and surfaces patterns through automatic correlation detection. The architectural decision that defines it: observations stored in Neo4j, where correlation queries become natural graph traversals rather than complex SQL joins. Relationships as the primary data structure, not an afterthought.',
 		techLine: 'SvelteKit 2 / Svelte 5 / TypeScript / Neo4j'
 	},
 	{
 		title: 'ReDoT',
-		repo: 'redot',
+		repo: 'fac-31/ReDoT',
 		description:
 			'A GitHub Action that auto-generates and updates code documentation using AI when pull requests are opened. Analyses which functions were actually modified, determines if documentation updates are needed, and creates or updates JSDoc comments and central documentation. Published with 9 releases. Three-person collaborative project.',
 		techLine: 'TypeScript / GitHub Actions / Claude API'
@@ -48,14 +48,14 @@ export const impactProjects: Omit<Project, 'github'>[] = [
 export const explorationProjects: Omit<Project, 'github'>[] = [
 	{
 		title: 'The Work',
-		repo: 'the-work',
+		repo: 'JasonWarrenUK/the-work',
 		description:
 			'A narrative game about writing a PhD thesis in one night while staving off existential angst. Built with a custom Ink/Svelte runtime engine (Nib) that\'s extractable for reuse. 67 observations across 7 intellectual domains, an orthodoxy scoring system, 21 emergent disciplines from domain pairings, and a thesis defence that adapts to what you\'ve written. The game\'s idea progression (Observation, Inkling, Idea, Concept, Argument, Thesis) is itself a knowledge system.',
 		techLine: 'SvelteKit / TypeScript / Ink (via inkjs) / Svelte 5 runes'
 	},
 	{
 		title: 'Epoch',
-		repo: 'epoch',
+		repo: 'JasonWarrenUK/epoch',
 		description:
 			'Create a fictional character, give them a lifetime, and discover what historical events they would have lived through. Transforms abstract history into personal narrative. Wikipedia API integration with significance ranking through Wikidata sitelinks, entity-type detection, named-event prefixes, and link density. Content filtering that strips sports results and malformed markup.',
 		techLine: 'SvelteKit 2 / Svelte 5 / Tailwind 4 / DaisyUI 5 / Wikipedia + Wikidata APIs',
@@ -63,7 +63,7 @@ export const explorationProjects: Omit<Project, 'github'>[] = [
 	},
 	{
 		title: 'Flyt',
-		repo: 'flyt',
+		repo: 'JasonWarrenUK/flyt',
 		description:
 			'A Norse contest of words: defend your honour through flyting, the ancient art of ritualised insult poetry. Interactive fiction built with DendryNexus and Svelte 5. Different narrative engine to The Work (DendryNexus vs Ink), same Svelte wrapper pattern. Custom .dry story file compilation pipeline.',
 		techLine: 'SvelteKit / TypeScript / DendryNexus / Svelte 5',
@@ -71,7 +71,7 @@ export const explorationProjects: Omit<Project, 'github'>[] = [
 	},
 	{
 		title: 'Those Who Came Before',
-		repo: 'those-who-came-before',
+		repo: 'JasonWarrenUK/those-who-came-before',
 		description:
 			'Try to understand a vanished culture by interpreting procedurally generated artefacts. Procedural archaeology with dual objective/subjective world states. Diegetic contradiction resolution. The player\'s interpretation is the gameplay. Structured backlog and dev documentation.',
 		techLine: 'SvelteKit / Svelte 5 / TypeScript'
@@ -81,14 +81,14 @@ export const explorationProjects: Omit<Project, 'github'>[] = [
 export const metaProjects: Omit<Project, 'github'>[] = [
 	{
 		title: 'Goblin Mode',
-		repo: 'goblin-mode',
+		repo: 'JasonWarrenUK/goblin-mode',
 		description:
 			'"Three goblins in a trenchcoat pretending to be a senior developer." A Claude Code configuration framework (50+ slash commands, 12 passive skills, 3 autonomous agents, git hooks) built around ADHD-aware friction design and context window discipline. Weakness-aware design: testing is a known weakness, so a dedicated skill encodes the discipline; ADHD makes executive function unreliable, so hooks enforce it. Model tier thinking maps Haiku/Sonnet/Opus to task complexity. The process of building it is the transferable skill, not the specifics.',
 		techLine: 'Shell / Claude Code / CLAUDE.md'
 	},
 	{
 		title: 'Nib',
-		repo: 'the-work',
+		repo: 'JasonWarrenUK/the-work',
 		description:
 			'A generic Ink + Svelte 5 runtime engine extracted from The Work. Handles story loading, reactive state via Svelte 5 runes, tag processing, and save/load, with zero knowledge of any particular game\'s mechanics. Game-specific logic is injected through a single onInit callback. Copy src/lib/engine/ to any SvelteKit project and it works. The ability to identify a reusable abstraction inside a bespoke project and extract it cleanly.',
 		techLine: 'SvelteKit / TypeScript / Ink (via inkjs) / Svelte 5 runes'

--- a/src/lib/utils/github.ts
+++ b/src/lib/utils/github.ts
@@ -1,6 +1,5 @@
 import type { ProjectGitHubData } from '$lib/types';
 
-const GITHUB_USER = 'JasonWarrenUK';
 const API_BASE = 'https://api.github.com';
 
 async function fetchJson<T>(url: string): Promise<T | null> {
@@ -26,8 +25,8 @@ interface ContributorResponse {
 	login: string;
 }
 
-export async function fetchRepoData(repoName: string): Promise<ProjectGitHubData | null> {
-	const repoUrl = `${API_BASE}/repos/${GITHUB_USER}/${repoName}`;
+export async function fetchRepoData(repoPath: string): Promise<ProjectGitHubData | null> {
+	const repoUrl = `${API_BASE}/repos/${repoPath}`;
 
 	const [repo, languages, contributors] = await Promise.all([
 		fetchJson<RepoResponse>(repoUrl),

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -8,7 +8,7 @@ export const load: PageServerLoad = async () => {
 		...impactProjects.map((p) => p.repo),
 		...explorationProjects.map((p) => p.repo),
 		...metaProjects.map((p) => p.repo)
-	];
+	].filter((repo) => repo.length > 0);
 
 	let githubData: Record<string, ProjectGitHubData | null> = {};
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -103,7 +103,7 @@
 
 <Section id="impact" title="Impact Work" accent="primary">
 	{#each withGithub(impactProjects) as project}
-		{#if project.repo === 'iris'}
+		{#if project.repo === 'foundersandcoders/iris'}
 			<ProjectCard {project} accent="primary">
 				<Terminal frames={irisSession} title="iris validate" />
 			</ProjectCard>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -32,9 +32,9 @@
 	const sectionTints: Record<string, string> = {
 		top: '#0f0e0d',
 		about: '#0f0e0d',
-		impact: '#0f1214',
-		explorations: '#14100f',
-		meta: '#130f11',
+		impact: '#0d1a1f',
+		explorations: '#1a140f',
+		meta: '#1a0f16',
 		background: '#0f0e0d',
 		artefacts: '#0f0e0d',
 		contact: '#0f0e0d'


### PR DESCRIPTION
## Summary
This PR refactors the project data structure to support full GitHub repository paths (e.g., `foundersandcoders/iris` instead of just `iris`), enabling projects from multiple GitHub organizations. It also improves the ProjectCard component's text splitting logic and visual presentation.

## Key Changes

- **GitHub repo path support**: Updated all project repo references to use full paths (`owner/repo`). Impact projects now reference their actual organization repos (foundersandcoders, fac-30, fac-31) while personal projects use `JasonWarrenUK/repo`.

- **Improved sentence boundary detection**: Enhanced `splitOverview()` to handle both `. ` and `."` as sentence boundaries using regex matching, fixing edge cases where descriptions end with quoted sentences.

- **Better ProjectCard layout**: 
  - Moved children rendering inside the expandable detail section (only shows expand button if detail text or children exist)
  - Added hover effects to repository and live links with smooth color transitions
  - Made repository links conditional on `project.repo` existence

- **GitHub API flexibility**: Removed hardcoded `GITHUB_USER` constant and updated `fetchRepoData()` to accept full repo paths, allowing queries for repos from any GitHub organization.

- **Visual refinements**: Updated section background tints to slightly deeper, more saturated colors for better visual hierarchy.

- **Data validation**: Added filter to exclude empty repo strings when fetching GitHub data.

## Implementation Details

The repo path change is backward compatible at the API level—the GitHub API endpoint structure remains the same, just with a different path parameter. The ProjectCard component now properly handles the conditional rendering of expandable content, ensuring the expand button only appears when there's actual content to reveal.

https://claude.ai/code/session_01LMPpNukHVJWVNc3Wyfyegi