### PR TITLE
Fix scroll tint observers being tree-shaken from build

### DIFF
--- a/src/routes/+layout.ts
+++ b/src/routes/+layout.ts
@@ -1,1 +1,2 @@
 export const prerender = true;
+export const csr = true;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -13,9 +13,6 @@
 	import { irisSession } from '$lib/data/terminal';
 	import type { Project } from '$lib/types';
 
-	import { onMount } from 'svelte';
-	import { browser } from '$app/environment';
-
 	interface Props {
 		data: import('./$types').PageData;
 	}
@@ -40,9 +37,7 @@
 		contact: '#0f0e0d'
 	};
 
-	onMount(() => {
-		if (!browser) return;
-
+	$effect(() => {
 		const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 
 		// Reveal animations: only when motion is acceptable


### PR DESCRIPTION
The onMount callback containing both the reveal animations and scroll-driven background tint IntersectionObservers was being completely removed during Svelte 5 compilation. The compiled page component (nodes/2.*.js) contained zero observer, classList, or backgroundColor references.

Root cause: onMount only performed raw DOM side effects with no reactive dependencies, so the compiler stripped the entire callback.

Fix: Replace onMount with $effect rune, which the Svelte 5 compiler treats as non-removable. Also add explicit csr = true to +layout.ts to ensure client-side rendering is never implicitly disabled.

Verified: the compiled output now contains both IntersectionObserver instances and all section tint hex values (#06232e, #2e1208, #2a0820).

https://claude.ai/code/session_01LtU3tyurA4tmhNydfpWqKL