### PR TITLE
Improve portfolio based on external tone feedback

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -139,6 +139,18 @@
 		outline-offset: 2px;
 	}
 
+	button:focus-visible {
+		outline: 2px solid var(--accent-primary);
+		outline-offset: 4px;
+		background: color-mix(in srgb, var(--accent-primary) 10%, transparent);
+	}
+
+	nav a:focus-visible {
+		outline: 2px solid var(--accent-primary);
+		outline-offset: 4px;
+		border-radius: 2px;
+	}
+
 	/* ─── Links ─── */
 
 	a {
@@ -153,5 +165,59 @@
 
 	a:visited {
 		color: var(--accent-warm);
+	}
+}
+
+/* ─── Print ─── */
+
+@media print {
+	body {
+		background: #fff !important;
+		color: #1a1a1a !important;
+		font-size: 11pt;
+		line-height: 1.5;
+		transition: none;
+	}
+
+	nav,
+	.skip-link,
+	button,
+	.terminal-window,
+	svg {
+		display: none !important;
+	}
+
+	section {
+		padding: 1rem 0 !important;
+		break-inside: avoid;
+	}
+
+	article {
+		border-left-color: #ccc !important;
+		break-inside: avoid;
+	}
+
+	h1, h2, h3 {
+		color: #1a1a1a !important;
+		font-family: Georgia, serif;
+	}
+
+	p, span, div {
+		color: #333 !important;
+	}
+
+	a {
+		color: #1a1a1a !important;
+		text-decoration: underline;
+	}
+
+	a[href^="http"]::after {
+		content: " (" attr(href) ")";
+		font-size: 9pt;
+		color: #666;
+	}
+
+	.card-detail {
+		animation: none !important;
 	}
 }

--- a/src/app.html
+++ b/src/app.html
@@ -5,9 +5,17 @@
 		<link rel="icon" href="%sveltekit.assets%/favicon.svg" type="image/svg+xml" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<meta name="description" content="Jason Warren | Developer. Knowledge systems. Good software. For people who never get either." />
+		<meta property="og:title" content="Jason Warren | Developer" />
+		<meta property="og:description" content="Knowledge systems. Good software. For people who never get either." />
+		<meta property="og:type" content="website" />
+		<meta property="og:url" content="https://jasonwarrenuk.github.io" />
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="Jason Warren | Developer" />
+		<meta name="twitter:description" content="Knowledge systems. Good software. For people who never get either." />
 		<title>Jason Warren</title>
 		<link rel="preload" href="%sveltekit.assets%/fonts/PlayfairDisplay-Variable.ttf" as="font" type="font/ttf" crossorigin />
 		<link rel="preload" href="%sveltekit.assets%/fonts/Literata-Variable.ttf" as="font" type="font/ttf" crossorigin />
+		<link rel="preload" href="%sveltekit.assets%/fonts/FiraCode-Variable.ttf" as="font" type="font/ttf" crossorigin />
 		<link rel="preload" href="%sveltekit.assets%/fonts/JetBrainsMono-Variable.ttf" as="font" type="font/ttf" crossorigin />
 		%sveltekit.head%
 	</head>

--- a/src/lib/components/About.svelte
+++ b/src/lib/components/About.svelte
@@ -12,5 +12,8 @@
 			systems for these spaces; the kind of software that has to actually work for the people
 			inside it.
 		</p>
+		<p style="margin-top: 1rem; font-size: var(--text-sm); color: var(--text-secondary);">
+			More in <a href="#background">Background</a>.
+		</p>
 	</div>
 </section>

--- a/src/lib/components/Nav.svelte
+++ b/src/lib/components/Nav.svelte
@@ -7,6 +7,8 @@
 		{ id: 'artefacts', label: 'Artefacts' },
 		{ id: 'contact', label: 'Contact' }
 	];
+
+	let menuOpen = $state(false);
 </script>
 
 <nav
@@ -37,6 +39,23 @@
 				{/each}
 			</div>
 
+			<button
+				type="button"
+				class="md:hidden"
+				aria-label={menuOpen ? 'Close menu' : 'Open menu'}
+				aria-expanded={menuOpen}
+				onclick={() => menuOpen = !menuOpen}
+				style="color: var(--text-secondary); background: none; border: none; cursor: pointer; padding: 0.25rem;"
+			>
+				<svg width="20" height="20" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+					{#if menuOpen}
+						<path d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" />
+					{:else}
+						<path d="M3 5h14M3 10h14M3 15h14" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" />
+					{/if}
+				</svg>
+			</button>
+
 			<a
 				href="https://github.com/JasonWarrenUK"
 				target="_blank"
@@ -53,4 +72,26 @@
 			</a>
 		</div>
 	</div>
+
+	{#if menuOpen}
+		<div
+			class="md:hidden"
+			style="border-top: 1px solid var(--border); background-color: color-mix(in srgb, var(--bg-primary) 95%, transparent);"
+		>
+			<div class="mx-auto flex max-w-3xl flex-col gap-1 px-6 py-3">
+				{#each sections as section}
+					<a
+						href="#{section.id}"
+						class="no-underline transition-colors duration-300"
+						style="font-family: var(--font-body); font-size: var(--text-sm); color: var(--text-secondary); padding: 0.375rem 0;"
+						onclick={() => menuOpen = false}
+						onmouseenter={(e) => ((e.currentTarget as HTMLElement).style.color = 'var(--text-primary)')}
+						onmouseleave={(e) => ((e.currentTarget as HTMLElement).style.color = 'var(--text-secondary)')}
+					>
+						{section.label}
+					</a>
+				{/each}
+			</div>
+		</div>
+	{/if}
 </nav>

--- a/src/lib/components/ProjectCard.svelte
+++ b/src/lib/components/ProjectCard.svelte
@@ -17,14 +17,34 @@
 		none: 'var(--border)'
 	};
 
-	function formatLanguages(languages: Record<string, number>): string {
+	const langColors: Record<string, string> = {
+		TypeScript: 'var(--accent-primary)',
+		JavaScript: 'var(--accent-warm)',
+		Svelte: 'var(--accent-warm)',
+		CSS: 'var(--accent-secondary)',
+		HTML: 'var(--accent-secondary)',
+		Rust: 'var(--accent-warm)',
+		Shell: 'var(--accent-primary)',
+		Python: 'var(--accent-primary)'
+	};
+
+	function getLanguageSegments(languages: Record<string, number>): { lang: string; pct: number; color: string }[] {
 		const total = Object.values(languages).reduce((a, b) => a + b, 0);
-		if (total === 0) return '';
+		if (total === 0) return [];
+		const palette = [
+			'var(--accent-primary)',
+			'var(--accent-warm)',
+			'var(--accent-secondary)',
+			'var(--text-tertiary)'
+		];
 		return Object.entries(languages)
 			.sort(([, a], [, b]) => b - a)
 			.slice(0, 4)
-			.map(([lang, bytes]) => `${lang} ${Math.round((bytes / total) * 100)}%`)
-			.join(' · ');
+			.map(([lang, bytes], i) => ({
+				lang,
+				pct: Math.round((bytes / total) * 100),
+				color: langColors[lang] ?? palette[i] ?? 'var(--text-tertiary)'
+			}));
 	}
 
 	function formatDate(iso: string): string {
@@ -89,10 +109,18 @@
 	</p>
 
 	{#if project.github}
-		{#if Object.keys(project.github.languages).length > 0}
-			<p style="font-size: var(--text-xs); color: {accentColors[accent]}; margin-top: 0.5rem;">
-				{formatLanguages(project.github.languages)}
-			</p>
+		{@const segments = getLanguageSegments(project.github.languages)}
+		{#if segments.length > 0}
+			<div style="margin-top: 0.5rem;">
+				<div class="lang-bar" style="display: flex; height: 4px; border-radius: 2px; overflow: hidden; gap: 1px;">
+					{#each segments as seg}
+						<div style="width: {seg.pct}%; background: {seg.color};" title="{seg.lang} {seg.pct}%"></div>
+					{/each}
+				</div>
+				<p style="font-size: var(--text-xs); color: var(--text-tertiary); margin-top: 0.25rem;">
+					{segments.map(s => `${s.lang} ${s.pct}%`).join(' · ')}
+				</p>
+			</div>
 		{/if}
 	{/if}
 

--- a/src/lib/data/projects.ts
+++ b/src/lib/data/projects.ts
@@ -90,13 +90,7 @@ export const metaProjects: Omit<Project, 'github'>[] = [
 		title: 'Nib',
 		repo: 'JasonWarrenUK/the-work',
 		description:
-			'A generic Ink + Svelte 5 runtime engine extracted from The Work. Handles story loading, reactive state via Svelte 5 runes, tag processing, and save/load, with zero knowledge of any particular game\'s mechanics. Game-specific logic is injected through a single onInit callback. Copy src/lib/engine/ to any SvelteKit project and it works. The ability to identify a reusable abstraction inside a bespoke project and extract it cleanly.',
+			'A generic Ink + Svelte 5 runtime engine, living inside The Work\'s src/lib/engine/ directory. Handles story loading, reactive state via Svelte 5 runes, tag processing, and save/load, with zero knowledge of any particular game\'s mechanics. Game-specific logic is injected through a single onInit callback. Copy the engine directory to any SvelteKit project and it works. The ability to identify a reusable abstraction inside a bespoke project and extract it cleanly.',
 		techLine: 'SvelteKit / TypeScript / Ink (via inkjs) / Svelte 5 runes'
-	},
-	{
-		title: 'XSD -> TS',
-		repo: '',
-		description: '',
-		techLine: ''
 	}
 ];

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -95,6 +95,15 @@
 <svelte:head>
 	<title>Jason Warren | Developer</title>
 	<meta name="description" content="Knowledge systems. Good software. For people who never get either." />
+	{@html `<script type="application/ld+json">${JSON.stringify({
+		"@context": "https://schema.org",
+		"@type": "Person",
+		"name": "Jason Warren",
+		"url": "https://jasonwarrenuk.github.io",
+		"sameAs": ["https://github.com/JasonWarrenUK"],
+		"jobTitle": "Developer",
+		"knowsAbout": ["Knowledge Systems", "SvelteKit", "TypeScript", "Civic Technology"]
+	})}</script>`}
 </svelte:head>
 
 <Hero />
@@ -135,9 +144,9 @@
 
 </Section>
 
-<Background />
-
 <Artefacts {artefacts} />
+
+<Background />
 
 <Contact />
 


### PR DESCRIPTION
- Fix Fira Code font loading (add preload in app.html)
- Remove empty XSD → TS skeleton card from Meta
- Clarify Nib lives inside the-work repo
- Add Open Graph and Twitter Card meta tags
- Add JSON-LD Person structured data
- Replace text-only language percentages with visual stacked bars
  using site palette colours
- Add focus indicators for buttons and nav links
- Add mobile hamburger nav (visible below md breakpoint)
- Add print stylesheet (light background, hide interactive elements)
- Add Background link in About section
- Move Artefacts section above Background for better reading flow

https://claude.ai/code/session_018o5BxhGpDSVmKokE2y3Xui