### PR TITLE
Fix accessibility, extract inline styles, and clean up CSS

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -30,14 +30,6 @@
 	font-display: swap;
 }
 
-@font-face {
-	font-family: 'JetBrains Mono';
-	src: url('/fonts/JetBrainsMono-Italic-Variable.ttf') format('truetype');
-	font-weight: 100 800;
-	font-style: italic;
-	font-display: swap;
-}
-
 /* ─── Design Tokens & Base Styles ─── */
 
 @layer base {
@@ -165,6 +157,60 @@
 
 	a:visited {
 		color: var(--accent-warm);
+	}
+
+	/* ─── Nav Links ─── */
+
+	nav a {
+		color: var(--text-secondary);
+		text-decoration: none;
+	}
+
+	nav a:visited {
+		color: var(--text-secondary);
+	}
+
+	nav a:hover,
+	nav a:focus-visible {
+		color: var(--text-primary);
+	}
+
+	nav .nav-home,
+	nav .nav-home:visited {
+		color: var(--text-primary);
+	}
+
+	/* ─── Card Links ─── */
+
+	.card-links a {
+		color: var(--text-secondary);
+	}
+
+	.card-links a:visited {
+		color: var(--text-secondary);
+	}
+
+	.card-links a:hover,
+	.card-links a:focus-visible {
+		color: var(--text-primary);
+	}
+
+	/* ─── Shared Component Styles ─── */
+
+	.section-heading {
+		font-family: var(--font-display);
+		font-size: var(--text-2xl);
+		color: var(--text-primary);
+		margin-bottom: 2rem;
+	}
+
+	.pull-quote {
+		color: var(--text-secondary);
+		font-family: var(--font-display);
+		font-size: var(--text-lg);
+		font-style: italic;
+		line-height: 1.8;
+		padding-left: 1.5rem;
 	}
 }
 

--- a/src/lib/components/About.svelte
+++ b/src/lib/components/About.svelte
@@ -1,19 +1,30 @@
 <section id="about" class="mx-auto max-w-3xl px-6 py-32">
-	<h2
-		style="font-family: var(--font-display); font-size: var(--text-2xl); color: var(--text-primary); margin-bottom: 2rem;"
-	>
+	<h2 class="section-heading">
 		About
 	</h2>
 
-	<div style="color: var(--text-primary); line-height: 1.8;">
+	<div class="body-text">
 		<p>
 			The people who most need good software are usually the last to get it. Apprenticeship
 			compliance, special educational needs, peer-led curriculum, civic data. I design knowledge
 			systems for these spaces; the kind of software that has to actually work for the people
 			inside it.
 		</p>
-		<p style="margin-top: 1rem; font-size: var(--text-sm); color: var(--text-secondary);">
+		<p class="aside">
 			More in <a href="#background">Background</a>.
 		</p>
 	</div>
 </section>
+
+<style>
+	.body-text {
+		color: var(--text-primary);
+		line-height: 1.8;
+	}
+
+	.aside {
+		margin-top: 1rem;
+		font-size: var(--text-sm);
+		color: var(--text-secondary);
+	}
+</style>

--- a/src/lib/components/Artefacts.svelte
+++ b/src/lib/components/Artefacts.svelte
@@ -8,28 +8,63 @@
 	let { artefacts }: Props = $props();
 </script>
 
-<section id="artefacts" class="mx-auto max-w-3xl px-6 py-32" style="font-family: var(--font-mono);">
-	<h2
-		style="font-family: var(--font-mono); font-size: var(--text-2xl); color: var(--text-primary); margin-bottom: 2rem;"
-	>
+<section id="artefacts" class="artefacts-section mx-auto max-w-3xl px-6 py-32">
+	<h2 class="artefacts-heading">
 		Artefacts
 	</h2>
 
-	<ul class="space-y-3" style="list-style: none; padding: 0;">
+	<p class="artefacts-intro">
+		Smaller things. Side projects, experiments, and curios.
+	</p>
+
+	<ul class="artefacts-list space-y-3">
 		{#each artefacts as artefact}
 			<li class="reveal-section">
 				<a
 					href="https://github.com/JasonWarrenUK/{artefact.repo}"
 					target="_blank"
 					rel="noopener noreferrer"
-					style="font-size: var(--text-sm);"
+					class="artefact-link"
 				>
 					{artefact.name}
 				</a>
-				<span style="color: var(--text-tertiary); font-size: var(--text-sm);">
+				<span class="artefact-desc">
 					: {artefact.description}
 				</span>
 			</li>
 		{/each}
 	</ul>
 </section>
+
+<style>
+	.artefacts-section {
+		font-family: var(--font-mono);
+	}
+
+	.artefacts-heading {
+		font-family: var(--font-mono);
+		font-size: var(--text-2xl);
+		color: var(--text-primary);
+		margin-bottom: 2rem;
+	}
+
+	.artefacts-intro {
+		color: var(--text-secondary);
+		margin-bottom: 1.5rem;
+		font-size: var(--text-sm);
+	}
+
+	.artefacts-list {
+		list-style: none;
+		padding: 0;
+	}
+
+	.artefact-link {
+		font-size: var(--text-sm);
+	}
+
+	.artefact-desc {
+		color: var(--text-tertiary);
+		font-size: var(--text-sm);
+	}
+</style>

--- a/src/lib/components/Background.svelte
+++ b/src/lib/components/Background.svelte
@@ -1,11 +1,9 @@
 <section id="background" class="mx-auto max-w-3xl px-6 py-32">
-	<h2
-		style="font-family: var(--font-display); font-size: var(--text-2xl); color: var(--text-primary); margin-bottom: 2rem;"
-	>
+	<h2 class="section-heading">
 		Background
 	</h2>
 
-	<div style="color: var(--text-primary); line-height: 1.8;">
+	<div class="body-text">
 		<p>
 			Master's with Distinction, published author on immersive theatre. Trained at
 			Founders and Coders, the tuition-free, peer-led programme where each cohort teaches the
@@ -15,3 +13,10 @@
 		</p>
 	</div>
 </section>
+
+<style>
+	.body-text {
+		color: var(--text-primary);
+		line-height: 1.8;
+	}
+</style>

--- a/src/lib/components/Contact.svelte
+++ b/src/lib/components/Contact.svelte
@@ -1,15 +1,13 @@
 <section id="contact" class="mx-auto max-w-3xl px-6 py-32">
-	<h2
-		style="font-family: var(--font-display); font-size: var(--text-2xl); color: var(--text-primary); margin-bottom: 2rem;"
-	>
+	<h2 class="section-heading">
 		Contact
 	</h2>
 
-	<p style="color: var(--text-secondary); margin-bottom: 1.5rem;">
+	<p class="contact-intro">
 		Best reached by email.
 	</p>
 
-	<div class="flex gap-6" style="font-size: var(--text-base);">
+	<div class="contact-links flex gap-6">
 		<a href="mailto:jason@foundersandcoders.com">jason@foundersandcoders.com</a>
 		<a
 			href="https://github.com/JasonWarrenUK"
@@ -20,3 +18,14 @@
 		</a>
 	</div>
 </section>
+
+<style>
+	.contact-intro {
+		color: var(--text-secondary);
+		margin-bottom: 1.5rem;
+	}
+
+	.contact-links {
+		font-size: var(--text-base);
+	}
+</style>

--- a/src/lib/components/Hero.svelte
+++ b/src/lib/components/Hero.svelte
@@ -2,19 +2,20 @@
 </script>
 
 <section id="top" class="flex min-h-screen flex-col items-center justify-center px-6">
-	<h1 class="hero-name" style="font-family: var(--font-display); font-size: var(--text-hero); font-weight: 700; line-height: 1.1;">
+	<h1 class="hero-name">
 		Jason Warren
 	</h1>
-	<p
-		class="mt-6 max-w-lg text-center"
-		style="font-family: var(--font-body); font-size: var(--text-lg); color: var(--text-secondary); line-height: 1.6;"
-	>
+	<p class="hero-tagline mt-6 max-w-lg text-center">
 		Knowledge systems. Good software. For people who never get either.
 	</p>
 </section>
 
 <style>
 	.hero-name {
+		font-family: var(--font-display);
+		font-size: var(--text-hero);
+		font-weight: 700;
+		line-height: 1.1;
 		background: linear-gradient(
 			135deg,
 			#5b8a9a,
@@ -27,6 +28,13 @@
 		-webkit-background-clip: text;
 		-webkit-text-fill-color: transparent;
 		animation: iris-cycle 30s ease infinite;
+	}
+
+	.hero-tagline {
+		font-family: var(--font-body);
+		font-size: var(--text-lg);
+		color: var(--text-secondary);
+		line-height: 1.6;
 	}
 
 	@keyframes iris-cycle {

--- a/src/lib/components/Nav.svelte
+++ b/src/lib/components/Nav.svelte
@@ -11,16 +11,18 @@
 	let menuOpen = $state(false);
 </script>
 
+<svelte:window onkeydown={(e: KeyboardEvent) => {
+	if (e.key === 'Escape' && menuOpen) {
+		menuOpen = false;
+	}
+}} />
+
 <nav
 	class="fixed top-0 left-0 right-0 z-50 backdrop-blur-md"
 	style="background-color: color-mix(in srgb, var(--bg-primary) 80%, transparent); border-bottom: 1px solid var(--border); transition: background-color 600ms ease;"
 >
 	<div class="mx-auto flex max-w-3xl items-center justify-between px-6 py-3">
-		<a
-			href="#top"
-			class="no-underline"
-			style="font-family: var(--font-display); font-size: var(--text-lg); color: var(--text-primary);"
-		>
+		<a href="#top" class="nav-home nav-site-name no-underline">
 			Jason Warren
 		</a>
 
@@ -29,10 +31,7 @@
 				{#each sections as section}
 					<a
 						href="#{section.id}"
-						class="no-underline transition-colors duration-300"
-						style="font-family: var(--font-body); font-size: var(--text-sm); color: var(--text-secondary);"
-						onmouseenter={(e) => ((e.currentTarget as HTMLElement).style.color = 'var(--text-primary)')}
-						onmouseleave={(e) => ((e.currentTarget as HTMLElement).style.color = 'var(--text-secondary)')}
+						class="nav-link no-underline transition-colors duration-300"
 					>
 						{section.label}
 					</a>
@@ -41,11 +40,10 @@
 
 			<button
 				type="button"
-				class="md:hidden"
+				class="nav-menu-btn md:hidden"
 				aria-label={menuOpen ? 'Close menu' : 'Open menu'}
 				aria-expanded={menuOpen}
 				onclick={() => menuOpen = !menuOpen}
-				style="color: var(--text-secondary); background: none; border: none; cursor: pointer; padding: 0.25rem;"
 			>
 				<svg width="20" height="20" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
 					{#if menuOpen}
@@ -61,8 +59,7 @@
 				target="_blank"
 				rel="noopener noreferrer"
 				aria-label="GitHub profile"
-				style="color: var(--text-secondary);"
-				class="transition-colors duration-300 hover:!text-[var(--text-primary)]"
+				class="transition-colors duration-300"
 			>
 				<svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
 					<path
@@ -82,11 +79,8 @@
 				{#each sections as section}
 					<a
 						href="#{section.id}"
-						class="no-underline transition-colors duration-300"
-						style="font-family: var(--font-body); font-size: var(--text-sm); color: var(--text-secondary); padding: 0.375rem 0;"
+						class="nav-link no-underline transition-colors duration-300"
 						onclick={() => menuOpen = false}
-						onmouseenter={(e) => ((e.currentTarget as HTMLElement).style.color = 'var(--text-primary)')}
-						onmouseleave={(e) => ((e.currentTarget as HTMLElement).style.color = 'var(--text-secondary)')}
 					>
 						{section.label}
 					</a>
@@ -95,3 +89,24 @@
 		</div>
 	{/if}
 </nav>
+
+<style>
+	.nav-site-name {
+		font-family: var(--font-display);
+		font-size: var(--text-lg);
+	}
+
+	.nav-link {
+		font-family: var(--font-body);
+		font-size: var(--text-sm);
+		padding: 0.375rem 0;
+	}
+
+	.nav-menu-btn {
+		color: var(--text-secondary);
+		background: none;
+		border: none;
+		cursor: pointer;
+		padding: 0.25rem;
+	}
+</style>

--- a/src/lib/components/ProjectCard.svelte
+++ b/src/lib/components/ProjectCard.svelte
@@ -68,31 +68,30 @@
 </script>
 
 <article
-	class="reveal-section mb-12"
-	style="padding-left: 1.5rem; border-left: 2px solid {accentColors[accent]};"
+	class="card reveal-section mb-12"
+	style="border-left: 2px solid {accentColors[accent]};"
 >
-	<h3
-		style="font-family: var(--font-display); font-size: var(--text-xl); color: var(--text-primary); margin-bottom: 0.75rem;"
-	>
+	<h3 class="card-title">
 		{project.title}
 	</h3>
 
-	<p style="color: var(--text-primary); font-size: var(--text-base); line-height: 1.6; margin-bottom: 0.5rem; font-weight: 500;">
+	<p class="card-overview">
 		{overview}
 	</p>
 
 	{#if detail || children}
 		<button
 			type="button"
+			class="card-toggle"
 			onclick={() => expanded = !expanded}
-			style="color: {accentColors[accent]}; font-size: var(--text-sm); font-family: var(--font-mono); background: none; border: none; cursor: pointer; padding: 0; margin-bottom: 0.5rem;"
+			style="color: {accentColors[accent]};"
 		>
 			{expanded ? '▾ Less' : '▸ More'}
 		</button>
 
 		{#if expanded}
 			{#if detail}
-				<p class="card-detail" style="color: var(--text-secondary); line-height: 1.8; margin-bottom: 1rem;">
+				<p class="card-detail card-detail-text">
 					{detail}
 				</p>
 			{/if}
@@ -104,20 +103,20 @@
 		{/if}
 	{/if}
 
-	<p style="font-size: var(--text-sm); color: {accentColors[accent]}; font-family: var(--font-mono); margin-bottom: 0.75rem;">
+	<p class="card-tech" style="color: {accentColors[accent]};">
 		{project.techLine}
 	</p>
 
 	{#if project.github}
 		{@const segments = getLanguageSegments(project.github.languages)}
 		{#if segments.length > 0}
-			<div style="margin-top: 0.5rem;">
-				<div class="lang-bar" style="display: flex; height: 4px; border-radius: 2px; overflow: hidden; gap: 1px;">
+			<div class="lang-section">
+				<div class="lang-bar">
 					{#each segments as seg}
 						<div style="width: {seg.pct}%; background: {seg.color};" title="{seg.lang} {seg.pct}%"></div>
 					{/each}
 				</div>
-				<p style="font-size: var(--text-xs); color: var(--text-tertiary); margin-top: 0.25rem;">
+				<p class="lang-labels">
 					{segments.map(s => `${s.lang} ${s.pct}%`).join(' · ')}
 				</p>
 			</div>
@@ -125,15 +124,12 @@
 	{/if}
 
 	{#if project.repo}
-		<div class="mt-3 flex gap-4" style="font-size: var(--text-sm);">
+		<div class="card-links mt-3 flex gap-4">
 			<a
 				href="https://github.com/{project.repo}"
 				target="_blank"
 				rel="noopener noreferrer"
 				class="transition-colors duration-300"
-				style="color: var(--text-secondary);"
-				onmouseenter={(e) => ((e.currentTarget as HTMLElement).style.color = 'var(--text-primary)')}
-				onmouseleave={(e) => ((e.currentTarget as HTMLElement).style.color = 'var(--text-secondary)')}
 			>
 				Repository
 			</a>
@@ -143,9 +139,6 @@
 					target="_blank"
 					rel="noopener noreferrer"
 					class="transition-colors duration-300"
-					style="color: var(--text-secondary);"
-					onmouseenter={(e) => ((e.currentTarget as HTMLElement).style.color = 'var(--text-primary)')}
-					onmouseleave={(e) => ((e.currentTarget as HTMLElement).style.color = 'var(--text-secondary)')}
 				>
 					Live
 				</a>
@@ -155,8 +148,71 @@
 </article>
 
 <style>
+	.card {
+		padding-left: 1.5rem;
+	}
+
+	.card-title {
+		font-family: var(--font-display);
+		font-size: var(--text-xl);
+		color: var(--text-primary);
+		margin-bottom: 0.75rem;
+	}
+
+	.card-overview {
+		color: var(--text-primary);
+		font-size: var(--text-base);
+		line-height: 1.6;
+		margin-bottom: 0.5rem;
+		font-weight: 500;
+	}
+
+	.card-toggle {
+		font-size: var(--text-sm);
+		font-family: var(--font-mono);
+		background: none;
+		border: none;
+		cursor: pointer;
+		padding: 0;
+		margin-bottom: 0.5rem;
+	}
+
 	.card-detail {
 		animation: card-expand 200ms ease-out;
+	}
+
+	.card-detail-text {
+		color: var(--text-secondary);
+		line-height: 1.8;
+		margin-bottom: 1rem;
+	}
+
+	.card-tech {
+		font-size: var(--text-sm);
+		font-family: var(--font-mono);
+		margin-bottom: 0.75rem;
+	}
+
+	.lang-section {
+		margin-top: 0.5rem;
+	}
+
+	.lang-bar {
+		display: flex;
+		height: 4px;
+		border-radius: 2px;
+		overflow: hidden;
+		gap: 1px;
+	}
+
+	.lang-labels {
+		font-size: var(--text-xs);
+		color: var(--text-tertiary);
+		margin-top: 0.25rem;
+	}
+
+	.card-links {
+		font-size: var(--text-sm);
 	}
 
 	@keyframes card-expand {

--- a/src/lib/components/Section.svelte
+++ b/src/lib/components/Section.svelte
@@ -20,7 +20,8 @@
 
 <section {id} class="mx-auto max-w-3xl px-6 py-32">
 	<h2
-		style="font-family: var(--font-display); font-size: var(--text-2xl); color: var(--text-primary); margin-bottom: 3rem; padding-left: {accent !== 'none' ? '1rem' : '0'}; border-left: {accent !== 'none' ? `3px solid ${accentColors[accent]}` : 'none'};"
+		class="section-heading"
+		style="margin-bottom: 3rem; padding-left: {accent !== 'none' ? '1rem' : '0'}; border-left: {accent !== 'none' ? `3px solid ${accentColors[accent]}` : 'none'};"
 	>
 		{title}
 	</h2>

--- a/src/lib/components/Terminal.svelte
+++ b/src/lib/components/Terminal.svelte
@@ -59,31 +59,50 @@
 	bind:this={containerEl}
 	role="img"
 	aria-label="Terminal demonstration showing {title}"
-	class="reveal-section overflow-hidden rounded-lg"
-	style="background-color: var(--terminal-bg); border: 1px solid var(--border);"
+	class="terminal-window reveal-section overflow-hidden rounded-lg"
 >
 	<!-- Title bar -->
-	<div
-		class="flex items-center gap-2 px-4 py-2"
-		style="background-color: var(--bg-tertiary); border-bottom: 1px solid var(--border);"
-	>
-		<span class="inline-block h-3 w-3 rounded-full" style="background-color: #ef4444;"></span>
-		<span class="inline-block h-3 w-3 rounded-full" style="background-color: #f59e0b;"></span>
-		<span class="inline-block h-3 w-3 rounded-full" style="background-color: #22c55e;"></span>
-		<span class="ml-2" style="font-family: var(--font-mono); font-size: var(--text-xs); color: var(--accent-primary);">
+	<div class="terminal-titlebar flex items-center gap-2 px-4 py-2">
+		<span class="terminal-dot inline-block h-3 w-3 rounded-full" style="background-color: #ef4444;"></span>
+		<span class="terminal-dot inline-block h-3 w-3 rounded-full" style="background-color: #f59e0b;"></span>
+		<span class="terminal-dot inline-block h-3 w-3 rounded-full" style="background-color: #22c55e;"></span>
+		<span class="terminal-title ml-2">
 			{title}
 		</span>
 	</div>
 
 	<!-- Terminal content -->
 	<pre
-		class="overflow-x-auto p-4"
-		style="font-family: var(--font-mono); font-size: var(--text-sm); color: var(--terminal-text); line-height: 1.6; margin: 0;"
+		class="terminal-content overflow-x-auto p-4"
 	>{#each visibleLines as line}{line}
 {/each}{#if showCursor}<span class="cursor">█</span>{/if}</pre>
 </div>
 
 <style>
+	.terminal-window {
+		background-color: var(--terminal-bg);
+		border: 1px solid var(--border);
+	}
+
+	.terminal-titlebar {
+		background-color: var(--bg-tertiary);
+		border-bottom: 1px solid var(--border);
+	}
+
+	.terminal-title {
+		font-family: var(--font-mono);
+		font-size: var(--text-xs);
+		color: var(--accent-primary);
+	}
+
+	.terminal-content {
+		font-family: var(--font-mono);
+		font-size: var(--text-sm);
+		color: var(--terminal-text);
+		line-height: 1.6;
+		margin: 0;
+	}
+
 	.cursor {
 		animation: blink 1s step-end infinite;
 	}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -123,7 +123,7 @@
 </Section>
 
 <Section id="explorations" title="Explorations" accent="warm">
-	<p class="pull-quote mb-12" style="color: var(--text-secondary); font-family: var(--font-display); font-size: var(--text-lg); font-style: italic; line-height: 1.8; padding-left: 1.5rem; border-left: 2px solid var(--accent-warm);">
+	<p class="pull-quote mb-12" style="border-left: 2px solid var(--accent-warm);">
 		Projects that explore ideas through systems design. Each one takes a domain (history,
 		philosophy, narrative, poetry) and builds a system that lets users engage with it on its
 		own terms.
@@ -134,7 +134,7 @@
 </Section>
 
 <Section id="meta" title="Meta" accent="secondary">
-	<p class="pull-quote mb-12" style="color: var(--text-secondary); font-family: var(--font-display); font-size: var(--text-lg); font-style: italic; line-height: 1.8; padding-left: 1.5rem; border-left: 2px solid var(--accent-secondary);">
+	<p class="pull-quote mb-12" style="border-left: 2px solid var(--accent-secondary);">
 		How I think about tooling and workflow. Most developers use tools. Some configure them. This is
 		what happens when you encode your entire development methodology into a system.
 	</p>


### PR DESCRIPTION
- Replace mouse-only hover handlers with CSS :hover + :focus-visible rules
  so keyboard users get the same color feedback as mouse users
- Fix visited link color bleeding into nav and card links
- Add Escape key handler to close mobile menu
- Remove unused JetBrains Mono italic @font-face declaration
- Add intro text to Artefacts section
- Extract ~36 inline style attributes into scoped <style> blocks
  and shared CSS classes (.section-heading, .pull-quote, .card-links)
- Move svelte:window keydown handler to avoid a11y warning on <nav>

https://claude.ai/code/session_016TWMHPY6vW3N9QwJsMbDUX